### PR TITLE
Pull in the most recent changes from remote

### DIFF
--- a/behave_teamcity/__init__.py
+++ b/behave_teamcity/__init__.py
@@ -32,6 +32,9 @@ class TeamcityFormatter(Formatter):
         self.current_step = step
 
     def result(self, step_result):
+        text = u'%6s %s ... ' % (step_result.keyword, step_result.name)
+        self.msg.progressMessage(text)
+        
         if self.current_scenario.status == "untested":
             return
 

--- a/behave_teamcity/__init__.py
+++ b/behave_teamcity/__init__.py
@@ -40,7 +40,7 @@ class TeamcityFormatter(Formatter):
                              duration=str(self.current_scenario.duration), flowId=None)
 
         if self.current_scenario.status == "failed":
-            name = self.current_step.name
+            name = step_result.name
 
             error_msg = u"Step failed: {}".format(name)
             if self.current_step.table:

--- a/setup-config-fix
+++ b/setup-config-fix
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-    description-file = README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [metadata]
 description-file = README.md
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='behave-teamcity',
-    version="0.1.24",
+    version="0.1.25",
     packages=['behave_teamcity', ],
     url='https://github.com/iljabauer/behave-teamcity',
     download_url='https://github.com/iljabauer/behave-teamcity/releases/tag/0.1.23',


### PR DESCRIPTION
behave-teamcity got updated back in April, and we never grabbed the updates.

Notably, someone may have fixed our issue where the wrong step is shown as failing in the logs: https://github.com/iljabauer/behave-teamcity/pull/5