### PR TITLE
Skip the last scenario in a file

### DIFF
--- a/hudl_behave_teamcity/__init__.py
+++ b/hudl_behave_teamcity/__init__.py
@@ -101,4 +101,6 @@ class TeamcityFormatter(Formatter):
                              duration=str(self.current_scenario.duration), outcome=self.current_scenario.status, framework=os.environ['TEAMCITY_BUILDCONF_NAME'], service=os.environ['TEAMCITY_PROJECT_NAME'], environment=os.environ['SITE'], flowId=self.flow_id)
 
     def eof(self):
+        if self.current_scenario and self.current_scenario.status == "skipped":  # Check the last scenario in a feature, as scenario() won't
+            self.msg.testIgnored(self.current_scenario.name)
         self.msg.testSuiteFinished(self.current_feature.name)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='hudl_behave_teamcity',
-    version="0.1.43",
+    version="0.1.44",
     packages=['hudl_behave_teamcity'],
     url='https://github.com/hudl/behave-teamcity',
     author='Ilja Bauer',


### PR DESCRIPTION
Because of the behavior of Behave with the formatter, we never actually call the `scenario` method on the final scenario in a feature file if it gets skipped.

I'm not sure if this is the "right" place, but I am now getting `testIgnored` logs when running suites of skipped tests locally, which is good news for our test reporting.