### PR TITLE
Convert status to a string

### DIFF
--- a/hudl_behave_teamcity/__init__.py
+++ b/hudl_behave_teamcity/__init__.py
@@ -78,11 +78,16 @@ class TeamcityFormatter(Formatter):
         if self.current_scenario.status == "untested":
             return
 
-        if self.current_scenario.status == "passed":
-            self.msg.message('testFinished', name=self.current_scenario.name.encode(encoding='ascii', errors='replace'),
-                             duration=str(self.current_scenario.duration), outcome=self.current_scenario.status, framework=os.environ['TEAMCITY_BUILDCONF_NAME'], service=os.environ['TEAMCITY_PROJECT_NAME'], environment=os.environ['SITE'], flowId=self.flow_id)
+        status = self.current_scenario.status
+        if type(self.current_scenario.status) is not str:
+            # Behave 1.2.6 (not released yet) converts status into an enum, but we need to be backwards-compatible
+            status = status.name
 
-        if self.current_scenario.status == "failed":
+        if status == "passed":
+            self.msg.message('testFinished', name=self.current_scenario.name.encode(encoding='ascii', errors='replace'),
+                             duration=str(self.current_scenario.duration), outcome=str(status), framework=os.environ['TEAMCITY_BUILDCONF_NAME'], service=os.environ['TEAMCITY_PROJECT_NAME'], environment=os.environ['SITE'], flowId=self.flow_id)
+
+        if status == "failed":
             name = step_result.name
 
             error_msg = u"Step failed: {}".format(name.encode(encoding='ascii', errors='replace'))
@@ -98,7 +103,7 @@ class TeamcityFormatter(Formatter):
 
             self.msg.testFailed(self.current_scenario.name.encode(encoding='ascii', errors='replace'), message=error_msg, details=error_details)
             self.msg.message('testFinished', name=self.current_scenario.name.encode(encoding='ascii', errors='replace'),
-                             duration=str(self.current_scenario.duration), outcome=self.current_scenario.status, framework=os.environ['TEAMCITY_BUILDCONF_NAME'], service=os.environ['TEAMCITY_PROJECT_NAME'], environment=os.environ['SITE'], flowId=self.flow_id)
+                             duration=str(self.current_scenario.duration), outcome=str(status), framework=os.environ['TEAMCITY_BUILDCONF_NAME'], service=os.environ['TEAMCITY_PROJECT_NAME'], environment=os.environ['SITE'], flowId=self.flow_id)
 
     def eof(self):
         if self.current_scenario and self.current_scenario.status == "skipped":  # Check the last scenario in a feature, as scenario() won't

--- a/hudl_behave_teamcity/__init__.py
+++ b/hudl_behave_teamcity/__init__.py
@@ -79,13 +79,9 @@ class TeamcityFormatter(Formatter):
             return
 
         status = self.current_scenario.status
-        if type(self.current_scenario.status) is not str:
+        if type(status) is not str:
             # Behave 1.2.6 (not released yet) converts status into an enum, but we need to be backwards-compatible
             status = status.name
-
-        if status == "passed":
-            self.msg.message('testFinished', name=self.current_scenario.name.encode(encoding='ascii', errors='replace'),
-                             duration=str(self.current_scenario.duration), outcome=str(status), framework=os.environ['TEAMCITY_BUILDCONF_NAME'], service=os.environ['TEAMCITY_PROJECT_NAME'], environment=os.environ['SITE'], flowId=self.flow_id)
 
         if status == "failed":
             name = step_result.name
@@ -102,8 +98,9 @@ class TeamcityFormatter(Formatter):
             error_details = step_result.error_message
 
             self.msg.testFailed(self.current_scenario.name.encode(encoding='ascii', errors='replace'), message=error_msg, details=error_details)
-            self.msg.message('testFinished', name=self.current_scenario.name.encode(encoding='ascii', errors='replace'),
-                             duration=str(self.current_scenario.duration), outcome=str(status), framework=os.environ['TEAMCITY_BUILDCONF_NAME'], service=os.environ['TEAMCITY_PROJECT_NAME'], environment=os.environ['SITE'], flowId=self.flow_id)
+
+        self.msg.message('testFinished', name=self.current_scenario.name.encode(encoding='ascii', errors='replace'),
+                         duration=str(self.current_scenario.duration), outcome=status, framework=os.environ['TEAMCITY_BUILDCONF_NAME'], service=os.environ['TEAMCITY_PROJECT_NAME'], environment=os.environ['SITE'], flowId=self.flow_id)
 
     def eof(self):
         if self.current_scenario and self.current_scenario.status == "skipped":  # Check the last scenario in a feature, as scenario() won't


### PR DESCRIPTION
Status is an enum in behave 1.2.6 (not yet released). It performs string comparison correctly, though, because it was patched to be so. [reference](https://github.com/behave/behave/blob/8d54ee3/behave/model_core.py#L71)

However, this causes issues when we try to pass it through behave-teamcity and eventually teamcity-messages, because you cannot call `.decode()` on an enum.

This change is meant to be backwards-compatible, as it will continue if the status is a string.

Tested locally against Behave 1.2.6dev0 as of [this commit](https://github.com/behave/behave/commit/8d54ee3).