### PR TITLE
Encode error messages and details in ASCII

### DIFF
--- a/hudl_behave_teamcity/__init__.py
+++ b/hudl_behave_teamcity/__init__.py
@@ -93,9 +93,9 @@ class TeamcityFormatter(Formatter):
 
             if self.current_step.text:
                 text = ModelDescriptor.describe_docstring(self.current_step.text, None)
-                error_msg = u"{}\nText:\n{}".format(error_msg, text)
+                error_msg = u"{}\nText:\n{}".format(error_msg, text).encode(encoding='ascii', errors='replace')
 
-            error_details = step_result.error_message
+            error_details = step_result.error_message.encode(encoding='ascii', errors='replace')
 
             self.msg.testFailed(self.current_scenario.name.encode(encoding='ascii', errors='replace'), message=error_msg, details=error_details)
 


### PR DESCRIPTION
Sometimes, somehow, this fouls up logging. Especially when we're trying to use multiple formatters and outfiles on a single Behave run.

Tested locally by manually modifying files.