### PR TITLE
0.1.48 install latest Behave

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup
 
 setup(
     name='hudl_behave_teamcity',
-    version="0.1.47",
+    version="0.1.48",
     packages=['hudl_behave_teamcity'],
     url='https://github.com/hudl/behave-teamcity',
     author='Ilja Bauer',
     author_email='i.bauer@cuescience.de',
     description='TeamCity test report formatter for behave',
-    install_requires=["behave>=1.2.5,<=1.3", "teamcity-messages"],
+    install_requires=["behave", "teamcity-messages"],
     keywords=['testing', 'behave', 'teamcity', 'formatter', 'report']
 )


### PR DESCRIPTION
# hudl-behave-teamcity pull request

## What did you change and why?

Removed the version check for Behave -- we install Behave ourselves as part of the test running process, and because we have a single mirrored version of Behave on our internal PyPi server, it's deterministic already.

I tested this only with `pip` commands in a virtualenv locally: `pip install behave>=1.2.5` failed, but `pip install behave` successfully found our internal version.

## Checklist

- [x] Tested locally
- [x] Formatted changes with YAPF
- [x] Updated `version` in setup.py
